### PR TITLE
Update Formations

### DIFF
--- a/civs/assyrian.json
+++ b/civs/assyrian.json
@@ -122,7 +122,7 @@
 	],
 	"Formations":
 	[
-		"formations/scatter",
+		"formations/null",
 		"formations/box",
 		"formations/column_closed",
 		"formations/line_closed",

--- a/civs/egyptian.json
+++ b/civs/egyptian.json
@@ -203,7 +203,7 @@
 	],
 	"Formations":
 	[
-		"formations/scatter",
+		"formations/null",
 		"formations/box",
 		"formations/column_closed",
 		"formations/line_closed",

--- a/civs/etrus.json
+++ b/civs/etrus.json
@@ -86,7 +86,7 @@
 	],
 	"Formations":
 	[
-		"formations/scatter",
+		"formations/null",
 		"formations/box",
 		"formations/column_closed",
 		"formations/line_closed",

--- a/civs/hitt.json
+++ b/civs/hitt.json
@@ -86,7 +86,7 @@
 	],
 	"Formations":
 	[
-		"formations/scatter",
+		"formations/null",
 		"formations/box",
 		"formations/column_closed",
 		"formations/line_closed",

--- a/civs/mino.json
+++ b/civs/mino.json
@@ -59,7 +59,7 @@
 	],
 	"Formations":
 	[
-		"formations/scatter",
+		"formations/null",
 		"formations/box",
 		"formations/column_closed",
 		"formations/line_closed",

--- a/civs/myce.json
+++ b/civs/myce.json
@@ -59,7 +59,7 @@
 	],
 	"Formations":
 	[
-		"formations/scatter",
+		"formations/null",
 		"formations/box",
 		"formations/column_closed",
 		"formations/line_closed",

--- a/civs/nubian.json
+++ b/civs/nubian.json
@@ -86,7 +86,7 @@
 	],
 	"Formations":
 	[
-		"formations/scatter",
+		"formations/null",
 		"formations/box",
 		"formations/column_closed",
 		"formations/line_closed",

--- a/civs/seap.json
+++ b/civs/seap.json
@@ -86,7 +86,7 @@
 	],
 	"Formations":
 	[
-		"formations/scatter",
+		"formations/null",
 		"formations/box",
 		"formations/column_closed",
 		"formations/line_closed",

--- a/simulation/data/civs/assyrian.json
+++ b/simulation/data/civs/assyrian.json
@@ -122,7 +122,7 @@
 	],
 	"Formations":
 	[
-		"formations/scatter",
+		"formations/null",
 		"formations/box",
 		"formations/column_closed",
 		"formations/line_closed",

--- a/simulation/data/civs/egyptian.json
+++ b/simulation/data/civs/egyptian.json
@@ -203,7 +203,7 @@
 	],
 	"Formations":
 	[
-		"formations/scatter",
+		"formations/null",
 		"formations/box",
 		"formations/column_closed",
 		"formations/line_closed",

--- a/simulation/data/civs/etrus.json
+++ b/simulation/data/civs/etrus.json
@@ -86,7 +86,7 @@
 	],
 	"Formations":
 	[
-		"formations/scatter",
+		"formations/null",
 		"formations/box",
 		"formations/column_closed",
 		"formations/line_closed",

--- a/simulation/data/civs/hitt.json
+++ b/simulation/data/civs/hitt.json
@@ -86,7 +86,7 @@
 	],
 	"Formations":
 	[
-		"formations/scatter",
+		"formations/null",
 		"formations/box",
 		"formations/column_closed",
 		"formations/line_closed",

--- a/simulation/data/civs/mino.json
+++ b/simulation/data/civs/mino.json
@@ -59,7 +59,7 @@
 	],
 	"Formations":
 	[
-		"formations/scatter",
+		"formations/null",
 		"formations/box",
 		"formations/column_closed",
 		"formations/line_closed",

--- a/simulation/data/civs/myce.json
+++ b/simulation/data/civs/myce.json
@@ -59,7 +59,7 @@
 	],
 	"Formations":
 	[
-		"formations/scatter",
+		"formations/null",
 		"formations/box",
 		"formations/column_closed",
 		"formations/line_closed",

--- a/simulation/data/civs/nubian.json
+++ b/simulation/data/civs/nubian.json
@@ -86,7 +86,7 @@
 	],
 	"Formations":
 	[
-		"formations/scatter",
+		"formations/null",
 		"formations/box",
 		"formations/column_closed",
 		"formations/line_closed",

--- a/simulation/data/civs/seap.json
+++ b/simulation/data/civs/seap.json
@@ -86,7 +86,7 @@
 	],
 	"Formations":
 	[
-		"formations/scatter",
+		"formations/null",
 		"formations/box",
 		"formations/column_closed",
 		"formations/line_closed",


### PR DESCRIPTION
A18 came out, formations were re-enabled, and the `scatter` formation was renamed `null`

We should alter our civ files to match